### PR TITLE
aオプションが指定できるようにした

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -22,12 +22,8 @@ end
 
 params = ARGV.getopts('a')
 
-filenames =
-  if params['a']
-    Dir.glob('*', File::FNM_DOTMATCH)
-  else
-    Dir.glob('*')
-  end
+flags = params['a'] ? File::FNM_DOTMATCH : 0
+filenames = Dir.glob('*', flags)
 exit if filenames.empty?
 
 max_row = filenames.length.ceildiv(COLUMN_COUNT)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMN_COUNT = 3
 MULTIPLES_FOR_COLUMN_WIDTH = 8 # 列幅の長さはこの定数の倍数になる
 
@@ -18,7 +20,14 @@ def generate_output_rows(filenames, max_row, col_width)
   output_rows
 end
 
-filenames = Dir.glob('*')
+params = ARGV.getopts('a')
+
+filenames =
+  if params['a']
+    Dir.glob('*', File::FNM_DOTMATCH)
+  else
+    Dir.glob('*')
+  end
 exit if filenames.empty?
 
 max_row = filenames.length.ceildiv(COLUMN_COUNT)


### PR DESCRIPTION
#### 概要
lsコマンドに `-a` オプションを実装しました。
`-a` オプションを指定することで隠しファイル（ドットファイル）が表示されるようになります。