### PR TITLE
aオプションではなくrオプションが指定できるようにした

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -20,10 +20,9 @@ def generate_output_rows(filenames, max_row, col_width)
   output_rows
 end
 
-params = ARGV.getopts('a')
+params = ARGV.getopts('r')
 
-flags = params['a'] ? File::FNM_DOTMATCH : 0
-filenames = Dir.glob('*', flags)
+filenames = params['r'] ? Dir.glob('*').reverse : Dir.glob('*')
 exit if filenames.empty?
 
 max_row = filenames.length.ceildiv(COLUMN_COUNT)


### PR DESCRIPTION
#### 概要
lsコマンドに`-r`オプションが指定できるようにしました。
`-r`オプションを指定するとファイル名の並び順がファイル名の降順になります。
`-a`オプションはいったん指定できないようにしました。

#### 気になったこと
並び順を逆順にする処理を、ファイル名の取得時（Dir.glob）に行うのか、表示用の行を生成する関数（generate_output_rows）内で行うのか、迷いました。後者のやり方で実装する理由が言語化できなかったので、修正量の少ない前者の方法で実装しました。